### PR TITLE
[feat] add default user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Babashka [http-client](https://github.com/babashka/http-client): HTTP client for Clojure and babashka built on java.net.http
 
+## Unreleased
+
+- [#13](https://github.com/babashka/http-client/issues/13): Add a default user-agent header: `babashka.http-client/<released-version>` ([@lispyclouds](https://github.com/lispyclouds))
+
 ## 0.0.3
 
 - [#12](https://github.com/babashka/http-client/issues/12): Do not uncompress (empty) body of `:head` request

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ will be built into babashka.
 Use as a dependency in `deps.edn` or `bb.edn`:
 
 ``` clojure
-org.babashka/http-client {:mvn/version "0.0.2"}
+org.babashka/http-client {:mvn/version "0.0.3"}
 ```
 
 ## Rationale

--- a/src/babashka/http_client/internal.clj
+++ b/src/babashka/http_client/internal.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [send get])
   (:require
    [babashka.http-client.interceptors :as interceptors]
+   [babashka.http-client.internal.version :as iv]
    [clojure.string :as str])
   (:import
    [java.net URI URLEncoder]
@@ -71,7 +72,7 @@
   {:follow-redirects :always
    :request {:headers {:accept "*/*"
                        :accept-encoding ["gzip" "deflate"]
-                       :user-agent "babashka.http-client/0.0.3"}}})
+                       :user-agent (str "babashka.http-client/" iv/version)}}})
 
 (def ^HttpClient default-client
   (delay (client default-client-opts)))

--- a/src/babashka/http_client/internal.clj
+++ b/src/babashka/http_client/internal.clj
@@ -70,7 +70,8 @@
 (def default-client-opts
   {:follow-redirects :always
    :request {:headers {:accept "*/*"
-                       :accept-encoding ["gzip" "deflate"]}}})
+                       :accept-encoding ["gzip" "deflate"]
+                       :user-agent "babashka.http-client/0.0.3"}}})
 
 (def ^HttpClient default-client
   (delay (client default-client-opts)))

--- a/test/babashka/http_client_test.clj
+++ b/test/babashka/http_client_test.clj
@@ -215,7 +215,7 @@
                  (catch Exception e
                    (prn e))))
     (let [resp (http/get (str "http://localhost:" port)
-                           {:as :stream})
+                         {:as :stream})
           status (:status resp)
           headers (:headers resp)
           body (:body resp)]
@@ -248,7 +248,8 @@
   (let [resp (http/get "https://postman-echo.com/get")
         headers (-> resp :body (json/parse-string true) :headers)]
     (is (= "*/*" (:accept headers)))
-    (is (= "gzip, deflate" (:accept-encoding headers)))))
+    (is (= "gzip, deflate" (:accept-encoding headers)))
+    (is (= "babashka.http-client/0.0.3" (:user-agent headers)))))
 
 (deftest client-request-opts-test
   (let [client (http/client {:request {:headers {"x-my-header" "yolo"}}})
@@ -295,8 +296,8 @@
                        response))}
         ;; Add json interceptor add beginning of chain
         ;; It will be the first to see the request and the last to see the response
-        interceptors (cons json-interceptor interceptors/default-interceptors)
-        ]
+        interceptors (cons json-interceptor interceptors/default-interceptors)]
+
     (testing "interceptors on request"
       (let [resp (http/get "https://httpstat.us/200"
                              {:interceptors interceptors

--- a/test/babashka/http_client_test.clj
+++ b/test/babashka/http_client_test.clj
@@ -1,9 +1,12 @@
 (ns babashka.http-client-test
-  (:require [cheshire.core :as json]
-            [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojure.test :refer [deftest is testing]])
-  (:import (clojure.lang ExceptionInfo)))
+  (:require
+   [babashka.http-client.internal.version :as iv]
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   (clojure.lang ExceptionInfo)))
 
 ;; reload client so we're not testing the built-in namespace in bb
 
@@ -249,7 +252,7 @@
         headers (-> resp :body (json/parse-string true) :headers)]
     (is (= "*/*" (:accept headers)))
     (is (= "gzip, deflate" (:accept-encoding headers)))
-    (is (= "babashka.http-client/0.0.3" (:user-agent headers)))))
+    (is (= (str "babashka.http-client/" iv/version) (:user-agent headers)))))
 
 (deftest client-request-opts-test
   (let [client (http/client {:request {:headers {"x-my-header" "yolo"}}})


### PR DESCRIPTION
Modelled it after [curl](https://everything.curl.dev/http/requests/user-agent). Should a `resources/BABASHKA_HTTP_CLIENT_VERSION` be used?