### PR TITLE
Support java.net.URI as url request parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Babashka [http-client](https://github.com/babashka/http-client): HTTP client for Clojure and babashka built on java.net.http
 
+## Unreleased
+
+- Add support for java.net.URI as request uri parameter
+
 ## 0.1.8
 
 - Fix binary file uploads

--- a/src/babashka/http_client.clj
+++ b/src/babashka/http_client.clj
@@ -30,7 +30,7 @@
   Options:
 
   * `:uri` - the uri to request (required).
-     May be a string or map of `:schema` (required), `:host` (required), `:port`, `:path` and `:query`
+     May be a string or map of `:scheme` (required), `:host` (required), `:port`, `:path` and `:query`
   * `:headers` - a map of headers
   * `:method` - the request method: `:get`, `:post`, `:head`, `:delete`, `:patch` or `:put`
   * `:interceptors` - custom interceptor chain

--- a/src/babashka/http_client/internal.clj
+++ b/src/babashka/http_client/internal.clj
@@ -155,7 +155,7 @@
       (seq headers)            (.headers (into-array String (coerce-headers headers)))
       method                   (.method (method-keyword->str method) (->body-publisher body))
       timeout                  (.timeout (->timeout timeout))
-      uri                      (.uri (URI/create uri))
+      uri                      (.uri (URI/create (str uri)))
       version                  (.version (version-keyword->version-enum version)))))
 
 (defn- apply-interceptors [init interceptors k]

--- a/test/babashka/http_client_test.clj
+++ b/test/babashka/http_client_test.clj
@@ -57,6 +57,14 @@
   (println "===" (-> m :var meta :name))
   (println))
 
+(deftest request-uri-test
+  (is (= 200 (:status (http/head "http://localhost:12233/200"))))
+  (is (= 200 (:status (http/head {:scheme "http"
+                                  :host "localhost"
+                                  :port 12233
+                                  :path "/200"}))))
+  (is (= 200 (:status (http/head (java.net.URI. "http://localhost:12233/200"))))))
+
 (deftest get-test
   (is (str/includes? (:body (http/get "http://localhost:12233/200"))
                      "200"))


### PR DESCRIPTION
`(http/get (java.net.URI. "https://example.com"))` currently raises an exception.

The patch could be simply changing https://github.com/babashka/http-client/blob/main/src/babashka/http_client/internal.clj#L158
to something like `(.uri (if (uri? uri) uri (URI/create uri)))`.

But my actual use-case is requesting a URI that I receive from datomic or transit, and those are (for whatever reason?)
`com.cognitect.transit.URI` and `clojure.core/uri?` returns `false` for those.
So maybe changing the http_client code to use `(.uri (URI/create (str uri)))` would work with the transit and java.net URIs
but it's also a function call more. Not sure if that matters?

What do you think? Maybe it doesn't event make sense to support this.