### PR TITLE
Add query-params, form-params, body and basic-auth to request docstring

### DIFF
--- a/src/babashka/http_client.clj
+++ b/src/babashka/http_client.clj
@@ -35,6 +35,10 @@
   * `:method` - the request method: `:get`, `:post`, `:head`, `:delete`, `:patch` or `:put`
   * `:interceptors` - custom interceptor chain
   * `:client` - a client as produced by `client`. If not provided a default client will be used.
+  * `:query-params` - a map of query params. The values can be a list to send multiple params with the same key.
+  * `:form-params` - a map of form params to send in the request body.
+  * `:body` - a file, inputstream or string to send as the request body.
+  * `:basic-auth` - a sequence of `user` `password` or map with `:user` `:pass` used for basic auth.
   * `:async` - perform request asynchronously. The response will be a `CompletableFuture` of the response map.
   * `:async-then` - a function that is called on the async result if successful
   * `:async-catch` - a function that is called on the async result if exceptional


### PR DESCRIPTION
Not sure if they where missing on purpose, but I like them
documented in the docstring so I can check all available options
from cider instead of opening the readme.

-------

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.