### PR TITLE
Fix double wrapping of futures on exceptions during async requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Babashka [http-client](https://github.com/babashka/http-client): HTTP client for Clojure and babashka built on java.net.http
 
+## Unreleased
+
+- [#38](https://github.com/babashka/http-client/issues/38): Fix double wrapping of futures on exceptions during async requests ([@axvr](https://github.com/axvr))
+
 ## 0.4.12
 
 - Add `babashka.http-client.websocket` API (mostly based on hato, thanks [@gnarroway](https://github.com/gnarroway)). See [API docs](https://github.com/babashka/http-client/blob/main/API.md#babashka.http-client.websocket).

--- a/test/babashka/http_client_test.clj
+++ b/test/babashka/http_client_test.clj
@@ -404,6 +404,10 @@
                                                             :async-then (fn [resp]
                                                                           (:status resp))}))
     (is (= 200 @async-resp))
+    (def async-resp (http/get "http://localhost:12233/422" {:async true}))
+    (def ex (is (thrown-with-msg? java.util.concurrent.ExecutionException
+                                  #"^clojure.lang.ExceptionInfo: Exceptional status code: 422 "
+                                  @async-resp)))
     (def async-resp (http/get "http://localhost:12233/404" {:async true
                                                             :async-then (fn [resp]
                                                                           (:status resp))


### PR DESCRIPTION
The problem was that the function defined in the `.exceptional` method would run as expected, but if no `:async-catch` had been given, it returned an earlier instance of the future (`resp`).

This PR removes the returning of `resp` and only attaches an `.exceptional` handler (and `:async-then` handler), if provided.

Resolves: #38

---

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions
- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.