### PR TITLE
Fix accidental URI path decoding in uri-with-query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Babashka [http-client](https://github.com/babashka/http-client): HTTP client for
 
 ## Unreleased
 
-- Fix accidental URI path decoding in uri-with-query
+- [#68](https://github.com/babashka/http-client/issues/68) Fix accidental URI path decoding in uri-with-query
 
 ## 0.4.20 (2024-08-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Babashka [http-client](https://github.com/babashka/http-client): HTTP client for Clojure and babashka built on java.net.http
 
+## Unreleased
+
+- Fix accidental URI path decoding in uri-with-query
+
 ## 0.4.20 (2024-08-13)
 
 - [#60](https://github.com/babashka/http-client/issues/60): Minimum Clojure version is now 1.10 instead of 1.11

--- a/src/babashka/http_client/interceptors.clj
+++ b/src/babashka/http_client/interceptors.clj
@@ -109,7 +109,7 @@
     (java.net.URI.
      (str (.getScheme uri) "://"
           (.getAuthority uri)
-          (.getPath uri)
+          (.getRawPath uri)
           (when-let [nq new-query]
             (str "?" nq))
           (when-let [f (.getFragment uri)]
@@ -127,12 +127,12 @@
                 opts))})
 
 (comment
-  (def uri (java.net.URI. "https://borkdude:foobar@foobar.net:80/?q=1#/dude"))
+  (def uri (java.net.URI. "https://borkdude:foobar@foobar.net:80/single%2felement?q=1#/dude"))
   (.getScheme uri) ;;=> https
   (.getSchemeSpecificPart uri) ;;=> //foobar.net/?q=1
   (.getUserInfo uri) ;;=> nil
   (.getAuthority uri) ;;=> "foobar.net"
-  (.getPath uri) ;;=> "/"
+  (.getRawPath uri) ;;=> "/single%2felement"
   (.getQuery uri) ;;=> q=1
   (.getFragment uri) ;;=> nil
   (uri-with-query uri "f=dude%26hello"))

--- a/test/babashka/http_client_test.clj
+++ b/test/babashka/http_client_test.clj
@@ -539,12 +539,12 @@
 (deftest uri-with-query-params-test
   (when (resolve `i/uri-with-query)
     (is (=
-         "https://borkdude:foobar@foobar.net:80/?q=%26moo#/dude"
-         (str (#'i/uri-with-query (java.net.URI. "https://borkdude:foobar@foobar.net:80/#/dude")
+         "https://borkdude:foobar@foobar.net:80/single%2felement?q=%26moo#/dude"
+         (str (#'i/uri-with-query (java.net.URI. "https://borkdude:foobar@foobar.net:80/single%2felement#/dude")
                                   "q=%26moo"))))
     (is (=
-         "https://borkdude:foobar@foobar.net:80/?q=1&q=%26moo#/dude"
-         (str (#'i/uri-with-query (java.net.URI. "https://borkdude:foobar@foobar.net:80/?q=1#/dude")
+         "https://borkdude:foobar@foobar.net:80/single%2felement?q=1&q=%26moo#/dude"
+         (str (#'i/uri-with-query (java.net.URI. "https://borkdude:foobar@foobar.net:80/single%2felement?q=1#/dude")
                                   "q=%26moo"))))))
 
 (deftest ring-client-test


### PR DESCRIPTION
This changes URI getPath to getRawPath to prevent accidental decoding.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
