### PR TITLE
fix typo of doc for babashka.http-client.websocket

### DIFF
--- a/API.md
+++ b/API.md
@@ -446,7 +446,7 @@ Sends a message to the WebSocket.
 
 Builds `java.net.http.Websocket` client.
   * `:uri` - the uri to request (required).
-     May be a string or map of `:schema` (required), `:host` (required), `:port`, `:path` and `:query`
+     May be a string or map of `:scheme` (required), `:host` (required), `:port`, `:path` and `:query`
   * `:headers` - a map of headers for the initial handshake`
   * `:client` - a client as produced by `client`. If not provided a default client will be used.
   * `:connect-timeout` Sets a timeout for establishing a WebSocket connection (in millis).

--- a/src/babashka/http_client/websocket.clj
+++ b/src/babashka/http_client/websocket.clj
@@ -10,7 +10,7 @@
 (defn websocket
   "Builds `java.net.http.Websocket` client.
   * `:uri` - the uri to request (required).
-     May be a string or map of `:schema` (required), `:host` (required), `:port`, `:path` and `:query`
+     May be a string or map of `:scheme` (required), `:host` (required), `:port`, `:path` and `:query`
   * `:headers` - a map of headers for the initial handshake`
   * `:client` - a client as produced by `client`. If not provided a default client will be used.
   * `:connect-timeout` Sets a timeout for establishing a WebSocket connection (in millis).


### PR DESCRIPTION
fix doc typo of babashka.http-client.websocke, remplacing doc mentions of `:schema` by `:scheme`.

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
