### PR TITLE
Add default port to ->uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Babashka [http-client](https://github.com/babashka/http-client): HTTP client for
 
 - [#71](https://github.com/babashka/http-client/issues/71): Link back to sources in release artifact
 ([@lread](https://github.com/lread))
+- [#73](https://github.com/babashka/http-client/issues/71): Allow implicit ports when specifying the URL as a map ([@lvh](https://github.com/lvh))
 
 ## 0.4.21 (2024-09-10)
 

--- a/src/babashka/http_client/internal/helpers.clj
+++ b/src/babashka/http_client/internal/helpers.clj
@@ -8,7 +8,7 @@
         (java.net.URI. ^String (:scheme uri)
                        ^String (:user uri)
                        ^String (:host uri)
-                       ^Integer (:port uri)
+                       ^Integer (:port uri -1)
                        ^String (:path uri)
                        ^String (:query uri)
                        ^String (:fragment uri))

--- a/test/babashka/http_client/internal/helpers_test.clj
+++ b/test/babashka/http_client/internal/helpers_test.clj
@@ -1,0 +1,8 @@
+(ns babashka.http-client.internal.helpers-test
+  (:require
+   [babashka.http-client.internal.helpers :as h]
+   [clojure.test :as t]))
+
+(t/deftest ->uri-tests
+  (let [uri (h/->uri {:scheme "https" :host "example.com" :path "/foo"})]
+    (t/is (= (.getPort uri) -1))))


### PR DESCRIPTION
Fixes #73.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code). (#73)

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

FYI: while there is a test exercising `->uri`, it only  makes a HEAD request against a local dev server, which runs against some unprivileged port, so the port was always explicitly specified, hiding the bug.

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
